### PR TITLE
[Docs][Small Refactor] NPM scripts for README generation, lean on ES features a little more

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Why is there also a JSON file?
 - it can be directly consumed by apps
 - README.md can be generated from json file so you only have to make changes in one place
 
-## Contributing 
+## Contributing
 1. Fork it
 2. Add your resource to `README.md` and `questions.json`
 3. Create new Pull Request

--- a/README.md
+++ b/README.md
@@ -356,6 +356,6 @@ Why is there also a JSON file?
 
 ## Contributing
 1. Fork repo
-2. Add your question to `questions.json` or `README.md` updates to `index.js`
-3. Run `npm start` to regenerate `README.md`
+2. Add your question to `questions.json` or provide README.md updates through `index.js`
+3. Run `npm start` to regenerate README.md
 4. Create new Pull Request

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Why is there also a JSON file?
 - README.md can be generated from json file so you only have to make changes in one place
 
 ## Contributing
-1. Fork it
-2. Add your resource to `README.md` and `questions.json`
-3. Create new Pull Request
+1. Fork repo
+2. Add your question to `questions.json` or `README.md` updates to `index.js`
+3. Run `npm start` to regenerate `README.md`
+4. Create new Pull Request

--- a/index.js
+++ b/index.js
@@ -42,9 +42,10 @@ Why is there also a JSON file?
 - README.md can be generated from json file so you only have to make changes in one place`;
 const contributing = `
 ## Contributing
-1. Fork it
-2. Add your resource to \`README.md\` and \`questions.json\`
-3. Create new Pull Request
+1. Fork repo
+2. Add your question to \`questions.json\` or \`README.md\` updates to \`index.js\`
+3. Run \`npm start\` to regenerate \`README.md\`
+4. Create new Pull Request
 `;
 
 const categoryMap = questions.reduce(categoryMapReducer, {});

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const faq = `
 
 Why is there also a JSON file?
 - it can be directly consumed by apps
-- README.md can be generated from json file so you only have to make changes in one place`;
+- \`README.md\` can be generated from json file so you only have to make changes in one place`;
 const contributing = `
 ## Contributing
 1. Fork repo

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function categoryMapReducer (accumulator, item) {
   }
   return accumulator;
 };
-function sectionReducer (accumulator, [category, items]) {
+function questionSectionReducer (accumulator, [category, items]) {
   return [
     ...accumulator,
     `\n\n## ${category}`,
@@ -39,20 +39,20 @@ const faq = `
 
 Why is there also a JSON file?
 - it can be directly consumed by apps
-- \`README.md\` can be generated from json file so you only have to make changes in one place`;
+- README.md can be generated from json file so you only have to make changes in one place`;
 const contributing = `
 ## Contributing
 1. Fork repo
-2. Add your question to \`questions.json\` or \`README.md\` updates to \`index.js\`
-3. Run \`npm start\` to regenerate \`README.md\`
+2. Add your question to \`questions.json\` or provide README.md updates through \`index.js\`
+3. Run \`npm start\` to regenerate README.md
 4. Create new Pull Request
 `;
 
 const categoryMap = questions.reduce(categoryMapReducer, {});
-const questionBySection = Object.entries(categoryMap).reduce(sectionReducer, []);
+const questionsBySection = Object.entries(categoryMap).reduce(questionSectionReducer, []);
 const content = [
   title,
-  ...questionBySection,
+  ...questionsBySection,
   faq,
   contributing
 ];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A list of 1 on 1 questions",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "npm run generate",
+    "generate": "node index.js"
   },
   "author": "Vidal Graupera",
   "license": "MIT"


### PR DESCRIPTION
Hello @VGraupera ! I hope this PR finds you well and in good spirits. I found this repo from a posting on [hacker news](https://news.ycombinator.com/item?id=22341138) and thought this project was really cool.

I looked through the code of `index.js` and saw some opportunities to lean on ES6 features more to simplify the program. It's mostly reorganization (e.g. move the question sort logic into its own function, update some variable names) and utilization of [array reducers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce), [spread (...) syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), and [destructuring assignments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).

I did ensured that the refactor did not change README.md output (see commit 3d56e47) and then updated the `contributing` instructions to deliver on the promise made in the FAQ (thus changing README.md output!)

> README.md can be generated from json file so you only have to make changes in one place

Check out my [fork's README.md](https://github.com/aallbrig/1on1-questions) if you would like to preview these changes before merging them into your repo.

I hope you think this changeset is worth having in your repo! Cheers!